### PR TITLE
Implemented 'Retrieve a single property value'

### DIFF
--- a/src/ODataParsedUrl.ts
+++ b/src/ODataParsedUrl.ts
@@ -4,4 +4,5 @@ export default class ODataParsedUrl {
     queryParams: any;
     id: string;  //if the url had a (Guid) parameter in it
     wasSingleRetrieve: boolean;
+    singleProperty?: string;
 }

--- a/src/ODataUrlParser.ts
+++ b/src/ODataUrlParser.ts
@@ -18,13 +18,13 @@ export default class ODataUrlParser implements IODataUrlParser {
             result.queryParams = null; //Empty query
         }
 
-        var entityNameWithIdRegex = /^([a-z0-9_])*\([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\)$/i;
+        var entityNameWithIdRegex = /^([a-z0-9_]+)\(([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\)(\/([a-z0-9_]+))?$/i;
         var match = entityNameWithIdRegex.exec(result.entitySetName);
 
         if(match && match.length > 0) {
-            var split = result.entitySetName.split('(');
-            result.entitySetName = split[0];
-            result.id = split[1].replace(")", "");
+            result.entitySetName = match[1];
+            result.id = match[2];
+            result.singleProperty = match[4];
             result.wasSingleRetrieve = true;
         }
         

--- a/src/XrmFakedContext.ts
+++ b/src/XrmFakedContext.ts
@@ -334,10 +334,12 @@ export class XrmFakedContext implements IXrmFakedContext
             entities.push(odataEntity);
         }
 
-        if(!parsedOData.wasSingleRetrieve) {
+        if (!parsedOData.wasSingleRetrieve) {
             response.value = entities;
         }
-        else {
+        else if (parsedOData.singleProperty) {
+            response.value = entities[0][parsedOData.singleProperty];
+        } else {
             response = entities[0];
         }
 

--- a/test/XrmFakedContext/query_tests.ts
+++ b/test/XrmFakedContext/query_tests.ts
@@ -34,7 +34,7 @@ describe("XrmFakedContext Queries: $select", function () {
 
     });
 
-    test("it should return a a single record if a single entity was requested", done => {
+    test("it should return a single record if a single entity was requested", done => {
         var existingId = Guid.create();
         context.initialize([
             new Entity("contact", Guid.create(), {firstname: 'Contact 1', other: "other"}),
@@ -43,6 +43,22 @@ describe("XrmFakedContext Queries: $select", function () {
 
         WebApiClient.retrieveMultiple("contacts(" + existingId.toString() + ")?$select=firstname", function (data) {
             expect(data.firstname).toBe("Contact 2");
+            expect(data.other).toBe(undefined);
+            
+            done();
+        });
+
+    });
+
+    test("it should return a single property if a single entity was requested and property specified", done => {
+        var existingId = Guid.create();
+        context.initialize([
+            new Entity("contact", Guid.create(), {firstname: 'Contact 1', other: "other"}),
+            new Entity("contact", existingId, {firstname: 'Contact 2', other: "Other2"})
+        ]);
+
+        WebApiClient.retrieveMultiple("contacts(" + existingId.toString() + ")/firstname", function (data) {
+            expect(data.value).toBe("Contact 2");
             expect(data.other).toBe(undefined);
             
             done();


### PR DESCRIPTION
Hello @jordimontana82 ,
I implemented the `Retrieve a single property value` described [here](https://docs.microsoft.com/en-us/powerapps/developer/common-data-service/webapi/retrieve-entity-using-web-api#retrieve-a-single-property-value).

I also changed the regex in `ODataUrlParser` to use match groups and avoid using substrings for url parts.

Best regards,
Betim.